### PR TITLE
Avoid issue with backend list surrounded with double quotes

### DIFF
--- a/add_backends.py
+++ b/add_backends.py
@@ -50,7 +50,7 @@ if sys.argv[1] == "hosts":
         print >> backends, recv_conf
 
 else:
-    hosts = os.environ['BACKENDS'].split()
+    hosts = os.environ['BACKENDS'].strip('"').split()
     for host in hosts:
         host_name_or_ip = host.split(':')[0]
         host_port = host.split(':')[1]


### PR DESCRIPTION
In case of BACKENDS list with only one BACKEND, double quotes are not correctly stripped and are present in the backend ip and port values.
