### PR TITLE
parameter strings escape

### DIFF
--- a/varnish/start.sh
+++ b/varnish/start.sh
@@ -5,24 +5,24 @@ set -e
 python /assemble_vcls.py
 
 # Priviledge separation user id
-if [ ! -z $PRIVILEDGED_USER ]; then
+if [[ ! -z $PRIVILEDGED_USER ]]; then
     PARAMS="$PARAMS -u $PRIVILEDGED_USER"
 fi
 
 # Size of the cache storage
-if [ ! -z $CACHE_SIZE ]; then
+if [[ ! -z $CACHE_SIZE ]]; then
     PARAMS="$PARAMS -s malloc,$CACHE_SIZE"
 else
     PARAMS="$PARAMS -s malloc,128M"
 fi
 
 # HTTP listen address and port
-if [ ! -z $ADDRESS_PORT ]; then
+if [[ ! -z $ADDRESS_PORT ]]; then
     PARAMS="$PARAMS -a $ADDRESS_PORT"
 fi
 
 # 'param-value' parameters
-if [ ! -z $PARAM_VALUE ]; then
+if [[ ! -z $PARAM_VALUE ]]; then
     PARAMS="$PARAMS $PARAM_VALUE"
 else
     PARAMS="$PARAMS -p default_ttl=3600 -p default_grace=3600"


### PR DESCRIPTION
Hello,

I had issues when I was trying to add multiple parameters to start varnishd :
`PARAM_VALUE=-s default=malloc,1G -s static=file,/var/lib/varnish/varnish_storage.bin,10G`
the `start.sh` file wasn't escaping the $PARAM_VALUE string and the -s flag was interpreted by bash causing the following error :

```
start.sh: line 25: [: -s: binary operator expected
```

This PR escapes the param strings and solves this problem.

This is for varnish:3 image.
