### PR TITLE
Fix newlines on /etc/varnish/default.vcl on reload

### DIFF
--- a/varnish/src/assemble_vcls.py
+++ b/varnish/src/assemble_vcls.py
@@ -3,7 +3,7 @@ import os
 with open("/etc/varnish/default.vcl", "r") as old_conf:
     with open("/etc/varnish/new_default.vcl", "w") as new_conf:
         lines = [line for line in old_conf
-                 if not line.startswith("#") and "include" not in line]
+                 if not line.startswith("#") and "include" not in line and not line == "\n" ]
 
         includes = os.listdir("/etc/varnish/conf.d")
         includes = ['include "/etc/varnish/conf.d/{name}";'.format(name=name)


### PR DESCRIPTION
Each time container is reloaded, default.vcl grows adding exta newlines.
This behavior makes this file grow until disk is filled on a
production system.
The fix wont copy newlines from original configuration preserving the
original file size

Related with #11 