### PR TITLE
add new probe header logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2013-03-23
+
+- Add Probe .request header support
+
 ## 2017-09-07 (4.1-3.1)
 
 - Release stable and immutable version: 4.1-3.1

--- a/varnish/Readme.md
+++ b/varnish/Readme.md
@@ -99,6 +99,19 @@ and then run
 
     $ docker build -t varnish-custom /path/to/Dockerfile
 
+### Support for specifying probe request headers
+
+Two environment variables support defining specific probe request headers.
+The primary warning / tricky part is around the delimiter used for separating 
+the individual headers. Below is an example:
+
+    BACKENDS_PROBE_REQUEST: 'GET / HTTP/1.1|Host: example.com|Connection: close|User-Agent: Varnish Health Probe'
+    BACKENDS_PROBE_REQUEST_DELIMITER: '|'
+
+The above will result in the probe being specified using the probe.request attribute
+and will replace the default probe.url attribute completely. 
+The important point, of course, is that you need to pick an appropriate delimiter
+that is not contained within any headers that you wish to pass. 
 
 ### Change and reload configuration without restarting the container
 
@@ -145,6 +158,8 @@ The varnish daemon can be configured by modifying the following environment vari
 * `DNS_ENABLED` DNS lookup provided `BACKENDS`. Use this option when your backends are resolved by an internal/external DNS service (e.g. Rancher)
 * `DNS_TTL` DNS lookup backends every $DNS_TTL minutes. Default 1 minute.
 * `BACKENDS_SAINT_MODE` Register backends using [saintmode module](https://github.com/varnish/varnish-modules/blob/master/docs/saintmode.rst)
+* `BACKENDS_PROBE_REQUEST` Backend probe request header list (default empty)
+* `BACKENDS_PROBE_REQUEST_DELIMITER` Backend probe request headers delimiter (default `|`)
 
 ## Copyright and license
 

--- a/varnish/src/add_backends.py
+++ b/varnish/src/add_backends.py
@@ -121,7 +121,6 @@ if sys.argv[1] == "dns":
             request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
             request = request[:-2] + ";"
             backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
-            print(backend_conf_add)
 
         backend_conf += backend_conf_add % dict(
                 name=name,
@@ -172,7 +171,6 @@ elif sys.argv[1] == "env":
             request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
             request = request[:-2] + ";"
             backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
-            print(backend_conf_add)
 
         backend_conf += backend_conf_add % dict(
                 name=name,
@@ -249,7 +247,6 @@ elif sys.argv[1] == "hosts":
             request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
             request = request[:-2] + ";"
             backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
-            print(backend_conf_add)
                     
         backend_conf += backend_conf_add % dict(
             name=name,

--- a/varnish/src/add_backends.py
+++ b/varnish/src/add_backends.py
@@ -15,6 +15,8 @@ BACKENDS_PROBE_INTERVAL = os.environ.get('BACKENDS_PROBE_INTERVAL', "1s").strip(
 BACKENDS_PROBE_WINDOW = os.environ.get('BACKENDS_PROBE_WINDOW', "3").strip()
 BACKENDS_PROBE_THRESHOLD = os.environ.get('BACKENDS_PROBE_THRESHOLD', "2").strip()
 BACKENDS_SAINT_MODE = os.environ.get("BACKENDS_SAINT_MODE", "").strip()
+BACKENDS_PROBE_REQUEST = os.environ.get('BACKENDS_PROBE_REQUEST', "").strip()
+BACKENDS_PROBE_REQUEST_DELIMITER = os.environ.get('BACKENDS_PROBE_DELIMITER', "|").strip()
 
 init_conf = """
 import std;
@@ -112,6 +114,15 @@ if sys.argv[1] == "dns":
     for ip, host in ips.items():
         name = toName(host)
         index = ip.replace('.', '_')
+
+        # replace probe .url with .request headers
+        if BACKENDS_PROBE_REQUEST:
+            hdrs = BACKENDS_PROBE_REQUEST.split(BACKENDS_PROBE_REQUEST_DELIMITER)
+            request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
+            request = request[:-2] + ";"
+            backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
+            print(backend_conf_add)
+
         backend_conf += backend_conf_add % dict(
                 name=name,
                 index=index,
@@ -154,6 +165,15 @@ elif sys.argv[1] == "env":
         host_name_or_ip = host_split[0]
         host_port = host_split[1] if len(host_split) > 1 else BACKENDS_PORT
         name = toName(host_name_or_ip)
+
+        # replace probe .url with .request headers
+        if BACKENDS_PROBE_REQUEST:
+            hdrs = BACKENDS_PROBE_REQUEST.split(BACKENDS_PROBE_REQUEST_DELIMITER)
+            request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
+            request = request[:-2] + ";"
+            backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
+            print(backend_conf_add)
+
         backend_conf += backend_conf_add % dict(
                 name=name,
                 index=index,
@@ -222,6 +242,15 @@ elif sys.argv[1] == "hosts":
 
         existing_hosts.add(host_ip)
         name = 'server'
+
+        # replace probe .url with .request headers
+        if BACKENDS_PROBE_REQUEST:
+            hdrs = BACKENDS_PROBE_REQUEST.split(BACKENDS_PROBE_REQUEST_DELIMITER)
+            request = '.request = \r\n' + ''.join([ '\t\t"'+item+'"\r\n' for item in hdrs])
+            request = request[:-2] + ";"
+            backend_conf_add = backend_conf_add .replace(r'.url = "%(probe_url)s";', request)
+            print(backend_conf_add)
+                    
         backend_conf += backend_conf_add % dict(
             name=name,
             index=index,


### PR DESCRIPTION
This update is contributed on behalf of the U.S. Department of Agriculture, Office Of Communications, Enterprise Web Application Platform and Services System.

Please review this PR in the context that we need the ability to specify the Host header used by the back-end probe when running a health-check against a specific back-end. The PR logic is based on the existence of two new ENV variables. If these are not defined, the behavior is the same as before the PR. The gist of the change is the VCL probe .url entry is replace with a multi-line .request entry consisting of user-defined headers. 

I'll create an additional PR to update the documentation to include the new variables and how their definition affects behavior, etc. 

Thanks