### PR TITLE
Probe request with hostname

### DIFF
--- a/varnish/Dockerfile
+++ b/varnish/Dockerfile
@@ -1,9 +1,20 @@
 FROM debian:jessie
 MAINTAINER "EEA: IDM2 A-Team" <eea-edw-a-team-alerts@googlegroups.com>
 
-COPY src/* /tmp/
+COPY src/docker-install.sh /tmp/docker-install.sh
 RUN /tmp/docker-install.sh \
  && rm -rvf /tmp/*
+
+COPY src/add_backends.py         /add_backends.py
+COPY src/assemble_vcls.py        /assemble_vcls.py
+COPY src/docker-entrypoint.sh    /docker-entrypoint.sh
+COPY src/track_hosts.sh          /track_hosts
+COPY src/track_dns.sh            /track_dns
+COPY src/reload.sh               /usr/bin/reload
+COPY src/default.vcl             /etc/varnish/default.vcl
+COPY src/docker-healthcheck.sh   /docker-healthcheck.sh
+COPY src/cookie_config.py        /cookie_config.py
+
 
 EXPOSE 6081 6085
 

--- a/varnish/Readme.md
+++ b/varnish/Readme.md
@@ -118,6 +118,11 @@ and will replace the default probe.url attribute completely.
 The important point, of course, is that you need to pick an appropriate delimiter
 that is not contained within any headers that you wish to pass.
 
+The hostname of the current backend being probed can be specify using the `%(hostname)s` placeholder:
+
+    BACKENDS_PROBE_REQUEST: 'GET / HTTP/1.1|Host: %(hostname)s|Connection: close|User-Agent: Varnish Health Probe'
+    BACKENDS_PROBE_REQUEST_DELIMITER: '|'
+
 ### Change and reload configuration without restarting the container
 
 If the configuration directory is mounted as a volume, you can modify

--- a/varnish/src/add_backends.py
+++ b/varnish/src/add_backends.py
@@ -126,6 +126,7 @@ if sys.argv[1] == "dns":
                 name=name,
                 index=index,
                 host=ip,
+                hostname=host,
                 port=port,
                 probe_url=BACKENDS_PROBE_URL,
                 probe_timeout=BACKENDS_PROBE_TIMEOUT,
@@ -176,6 +177,7 @@ elif sys.argv[1] == "env":
                 name=name,
                 index=index,
                 host=host_name_or_ip,
+                hostanme=host_name_or_ip,
                 port=host_port,
                 probe_url=BACKENDS_PROBE_URL,
                 probe_timeout=BACKENDS_PROBE_TIMEOUT,
@@ -235,6 +237,7 @@ elif sys.argv[1] == "hosts":
             continue
 
         host_ip = host.split()[0]
+        host_name = host.split()[1]
         if host_ip in existing_hosts:
             continue
 
@@ -252,6 +255,7 @@ elif sys.argv[1] == "hosts":
             name=name,
             index=index,
             host=host_ip,
+            hostname=host_name,
             port=BACKENDS_PORT,
             probe_url=BACKENDS_PROBE_URL,
             probe_timeout=BACKENDS_PROBE_TIMEOUT,

--- a/varnish/src/add_backends.py
+++ b/varnish/src/add_backends.py
@@ -177,7 +177,7 @@ elif sys.argv[1] == "env":
                 name=name,
                 index=index,
                 host=host_name_or_ip,
-                hostanme=host_name_or_ip,
+                hostname=host_name_or_ip,
                 port=host_port,
                 probe_url=BACKENDS_PROBE_URL,
                 probe_timeout=BACKENDS_PROBE_TIMEOUT,

--- a/varnish/src/docker-install.sh
+++ b/varnish/src/docker-install.sh
@@ -158,20 +158,3 @@ echo "========================================================================="
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-
-
-echo "========================================================================="
-echo "Configuration scripts"
-echo "========================================================================="
-
-mv -v /tmp/assemble_vcls.py   /assemble_vcls.py
-mv -v /tmp/add_backends.py    /add_backends.py
-mv -v /tmp/docker-entrypoint.sh    /docker-entrypoint.sh
-mv -v /tmp/track_hosts.sh     /track_hosts
-mv -v /tmp/track_dns.sh       /track_dns
-mv -v /tmp/reload.sh          /usr/bin/reload
-mv -v /tmp/default.vcl        /etc/varnish/default.vcl
-mv -v /tmp/docker-healthcheck.sh /docker-healthcheck.sh
-mv -v /tmp/cookie_config.py     /cookie_config.py
-
-


### PR DESCRIPTION
For my own use, I needed to set the `Host` http header to the probe url. 
I ended up modifying add_backends.py a bit for that purpose.

Now I can use:

```yaml
BACKENDS_PROBE_REQUEST: 'GET / HTTP/1.1|Host: %(hostname)s|Connection: close|User-Agent: Varnish Health Probe'
```