### PR TITLE
Update docker-healthcheck.sh

### DIFF
--- a/varnish/src/docker-healthcheck.sh
+++ b/varnish/src/docker-healthcheck.sh
@@ -7,7 +7,7 @@ PASS=${DASHBOARD_PASSWORD:-"admin"}
 PORT=${DASHBOARD_PORT:-"6085"}
 
 
-health=$(curl -s -u$USER:$PASS "http://localhost:$DASHBOARD_PORT/status")
+health=$(curl -s -u$USER:$PASS "http://localhost:$PORT/status")
 
 health=${health:-"Dashboard down"}
 


### PR DESCRIPTION
use $PORT variable instead of env var DASHBOARD_PORT

When no environment variable is configured, the curl request becomes;
http://localhost:/status
which yields a exit code 7, using the $PORT variable which falls back to the default, prevents this.